### PR TITLE
New PR not  entirely working

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9-slim
+FROM python:3.12-slim
 
 LABEL maintainer="Yves Guimard <yves.guimard@gmail.com>"
 

--- a/app/auth.py
+++ b/app/auth.py
@@ -61,7 +61,7 @@ def password_validity(password: str):
         return False
     elif not re.search("[0-9]" , password):
         return False
-    elif not re.search("[ !\"#$%&'()*+,-./:;<=>?@[\]^_`{|}~]" , password):
+    elif not re.search("[ !\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~]" , password):
         return False
     return True
     

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -9,7 +9,7 @@ class InstantAccess(BaseModel):
     unique_link: str = None
     description: Union[str, None] = None
     class Config:
-        orm_mode = True
+        from_attributes = True
 
 class InstantAccessCreate(InstantAccess):
     pass
@@ -21,7 +21,7 @@ class Ip(BaseModel):
     description: Union[str, None] = None
     origin: str = None
     class Config:
-        orm_mode = True
+        from_attributes = True
 
 class IpCreate(Ip):
     pass
@@ -34,7 +34,7 @@ class User(BaseModel):
     is_admin: Optional[bool] = False
     twofactor: str = None
     class Config:
-        orm_mode = True
+        from_attributes = True
 
 class UserCreate(User):
     password: str
@@ -49,7 +49,7 @@ class Token(BaseModel):
     secret: str = None
     description: Union[str, None] = None
     class Config:
-        orm_mode = True
+        from_attributes = True
 
 class TokenCreate(Token):
     pass

--- a/app/settings.py
+++ b/app/settings.py
@@ -2,7 +2,7 @@
 External settings configuration
 """
 import os
-from pydantic import BaseSettings
+from pydantic_settings import BaseSettings
 from dotenv import load_dotenv
 
 class Settings(BaseSettings):

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,8 +3,8 @@ uvicorn
 gunicorn
 sqlalchemy
 email-validator
-bcrypt
-passlib
+bcrypt==4.0.1
+passlib[bcrypt]
 python-jose
 python-multipart
 jinja2

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ jinja2
 requests
 python-dotenv
 pyotp
+pydantic-settings


### PR DESCRIPTION
-  Update python 3.12-slim
- Add pydantic-settings Basesettings as pydantic Basesettings was removed
- change org_mode to from_attributes
- correct regex by adding \ as python escaping it not properly
-  correct bcript __about__ error see https://github.com/logspace-ai/langflow/issues/1173

Error still having : 
```
squidgui  |   File "/usr/local/lib/python3.12/site-packages/starlette/routing.py", line 74, in app
squidgui  |     response = await func(request)
squidgui  |                ^^^^^^^^^^^^^^^^^^^
squidgui  |   File "/usr/local/lib/python3.12/site-packages/fastapi/routing.py", line 278, in app
squidgui  |     raw_response = await run_endpoint_function(
squidgui  |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
squidgui  |   File "/usr/local/lib/python3.12/site-packages/fastapi/routing.py", line 191, in run_endpoint_function
squidgui  |     return await dependant.call(**values)
squidgui  |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
squidgui  |   File "/app/routers/instant_access.py", line 52, in post_instant_access
squidgui  |     link_created = crud.create_instant_access(db=db, link=link, user_id=current_user.id, description=description)
squidgui  |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
squidgui  |   File "/app/crud.py", line 92, in create_instant_access
squidgui  |     ia = InstantAccessCreate(link=link, unique_link=unique_link, owner_id=user_id, description=description)
squidgui  |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
squidgui  |   File "/usr/local/lib/python3.12/site-packages/pydantic/main.py", line 171, in __init__
squidgui  |     self.__pydantic_validator__.validate_python(data, self_instance=self)
squidgui  | pydantic_core._pydantic_core.ValidationError: 1 validation error for InstantAccessCreate
squidgui  | id
squidgui  |   Field required [type=missing, input_value={'link': 'https://your_se...': 1, 'description': ''}, input_type=dict]
squidgui  |     For further information visit https://errors.pydantic.dev/2.6/v/missing
```
when adding instant-link or ips